### PR TITLE
Updated code base to be compatible with the final FF API in Java22

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,12 @@
 	<url>https://www.jnetpcap.org</url>
 	<properties>
 		<parent.project>${project.artifactId}</parent.project>
-		
-		<jdk.version>21</jdk.version>
+
+		<jdk.version>22</jdk.version>
 		<project.build.sourceEncoding>${java.encoding}</project.build.sourceEncoding>
 		<maven.compiler.source>${jdk.version}</maven.compiler.source>
 		<maven.compiler.target>${jdk.version}</maven.compiler.target>
-		<java.preview>--enable-preview</java.preview>
+		<java.preview/>
 		<java.encoding>UTF-8</java.encoding>
 		<java.native>--enable-native-access=ALL-UNNAMED</java.native>
 		<groups>user-permission</groups>
@@ -44,7 +44,7 @@
 			<artifactId>maven-compiler-plugin</artifactId>
 			<version>3.11.0</version>
 		</dependency>
-		<!-- 
+		<!--
 		https://mvnrepository.com/artifact/org.junit.platform/junit-platform-suite-api  -->
 		<dependency>
 			<groupId>org.junit.platform</groupId>
@@ -83,7 +83,7 @@
 					<source>${jdk.version}</source>
 					<target>${jdk.version}</target>
 					<release>${jdk.version}</release>
-					<enablePreview>true</enablePreview>
+					<enablePreview>false</enablePreview>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/java/org/jnetpcap/BpFilter.java
+++ b/src/main/java/org/jnetpcap/BpFilter.java
@@ -29,12 +29,12 @@ import static java.lang.foreign.ValueLayout.*;
 /**
  * A Berkley Packet Filter program. BpFilter is applied to captured packets and
  * only the packets that match the filter program are reported.
- * 
+ *
  * <p>
  * Each 64-bit instruction is the long int representation of the following bpf
  * structure found in C header file "pcap/bpf.h":
  * </p>
- * 
+ *
  * <pre>
  * struct bpf_insn {
  *		u_short	full;
@@ -43,7 +43,7 @@ import static java.lang.foreign.ValueLayout.*;
  *		bpf_u_int32 k;
  * };
  * </pre>
- * 
+ *
  * @author Sly Technologies
  * @author repos@slytechs.com
  */
@@ -56,11 +56,11 @@ public final class BpFilter implements AutoCloseable {
 	 * 		     struct bpf_insn *bf_insns;
 	 * 		 };
 	 * </pre>
-	 * 
+	 *
 	 * .
 	 */
 	private class StructBpfProgram {
-		
+
 		/** The Constant LAYOUT. */
 		private static final MemoryLayout LAYOUT = structLayout(
 
@@ -72,7 +72,7 @@ public final class BpFilter implements AutoCloseable {
 
 		/** The Constant BF_LEN. */
 		private static final VarHandle BF_LEN = LAYOUT.varHandle(groupElement("bf_len"));
-		
+
 		/** The Constant BF_INSNS. */
 		private static final VarHandle BF_INSNS = LAYOUT.varHandle(groupElement("bf_insns"));
 
@@ -106,7 +106,7 @@ public final class BpFilter implements AutoCloseable {
 		 * @return the memory segment
 		 */
 		public MemorySegment bf_insns() {
-			return (MemorySegment) BF_INSNS.get(ValueLayout.ADDRESS);
+			return (MemorySegment) BF_INSNS.get(this.mseg, 0L);
 		}
 
 		/**
@@ -115,7 +115,7 @@ public final class BpFilter implements AutoCloseable {
 		 * @return the int
 		 */
 		public int bf_len() {
-			return (int) BF_LEN.get(mseg);
+			return (int) BF_LEN.get(mseg, 0L);
 		}
 
 		/**
@@ -140,7 +140,7 @@ public final class BpFilter implements AutoCloseable {
 
 	/** The program. */
 	private final StructBpfProgram program;
-	
+
 	/** The arena. */
 	private final Arena arena;
 

--- a/src/main/java/org/jnetpcap/BpFilterInstruction.java
+++ b/src/main/java/org/jnetpcap/BpFilterInstruction.java
@@ -30,11 +30,11 @@ import java.lang.invoke.VarHandle;
  * BpFilter program instruction. Instructions are processed in binary mode but
  * for text formatting purposes or program analysis, this class decodes each
  * instruction.
- * 
+ *
  * <p>
  * Each 64-bit instruction is the long int representation of the following bpf
  * structure found in C header file "pcap/bpf.h":
- * 
+ *
  * <pre>
  * struct bpf_insn {
  *		u_short	full;
@@ -57,13 +57,13 @@ record BpFilterInstruction(int code, int jt, int jf, long k) {
 
 	/** The Constant CODE. */
 	private static final VarHandle CODE = LAYOUT.varHandle(sequenceElement(), groupElement("full"));
-	
+
 	/** The Constant JT. */
 	private static final VarHandle JT = LAYOUT.varHandle(sequenceElement(), groupElement("jt"));
-	
+
 	/** The Constant JF. */
 	private static final VarHandle JF = LAYOUT.varHandle(sequenceElement(), groupElement("jf"));
-	
+
 	/** The Constant K. */
 	private static final VarHandle K = LAYOUT.varHandle(sequenceElement(), groupElement("k"));
 
@@ -76,10 +76,10 @@ record BpFilterInstruction(int code, int jt, int jf, long k) {
 	 */
 	static BpFilterInstruction instructionAt(MemorySegment seg, int index) {
 		return new BpFilterInstruction(
-				Short.toUnsignedInt((short) CODE.get(seg, index)),
-				Byte.toUnsignedInt((byte) JT.get(seg, index)),
-				Byte.toUnsignedInt((byte) JF.get(seg, index)),
-				Integer.toUnsignedLong((int) K.get(seg, index)));
+				Short.toUnsignedInt((short) CODE.get(seg, 0L, index)),
+				Byte.toUnsignedInt((byte) JT.get(seg, 0L, index)),
+				Byte.toUnsignedInt((byte) JF.get(seg, 0L, index)),
+				Integer.toUnsignedLong((int) K.get(seg, 0L, index)));
 	}
 
 	/**

--- a/src/main/java/org/jnetpcap/Pcap0_4.java
+++ b/src/main/java/org/jnetpcap/Pcap0_4.java
@@ -321,7 +321,7 @@ public sealed class Pcap0_4 extends Pcap permits Pcap0_5 {
 
 			String dev = pcap_lookupdev.invokeString(errbuf);
 			if (dev == null)
-				throw new PcapException(errbuf.getUtf8String(0));
+				throw new PcapException(errbuf.getString(0, java.nio.charset.StandardCharsets.UTF_8));
 
 			return dev;
 		}
@@ -344,10 +344,10 @@ public sealed class Pcap0_4 extends Pcap permits Pcap0_5 {
 			MemorySegment pTop1 = arena.allocate(ADDRESS);
 			MemorySegment pTop2 = arena.allocate(ADDRESS);
 			MemorySegment errbuf = arena.allocate(PCAP_ERRBUF_SIZE);
-			MemorySegment dev = arena.allocateUtf8String(device);
+			MemorySegment dev = arena.allocateFrom(device, java.nio.charset.StandardCharsets.UTF_8);
 
 			int code = pcap_lookupnet.invokeInt(dev, pTop1, pTop2, errbuf);
-			PcapException.throwIfNotOk(code, () -> errbuf.getUtf8String(0));
+			PcapException.throwIfNotOk(code, () -> errbuf.getString(0, java.nio.charset.StandardCharsets.UTF_8));
 
 			int address = pTop1.get(ValueLayout.JAVA_INT, 0);
 			int netmask = pTop2.get(ValueLayout.JAVA_INT, 0);
@@ -376,7 +376,7 @@ public sealed class Pcap0_4 extends Pcap permits Pcap0_5 {
 			throws PcapException {
 
 		try (var arena = newArena()) {
-			MemorySegment c_device = arena.allocateUtf8String(requireNonNull(device, "device"));
+			MemorySegment c_device = arena.allocateFrom(requireNonNull(device, "device"), java.nio.charset.StandardCharsets.UTF_8);
 			MemorySegment errbuf = arena.allocate(PCAP_ERRBUF_SIZE);
 
 			int c_snaplen = snaplen;
@@ -387,7 +387,7 @@ public sealed class Pcap0_4 extends Pcap permits Pcap0_5 {
 					errbuf);
 
 			if (ForeignUtils.isNullAddress(pcapPointer))
-				throw new PcapException(PcapCode.PCAP_ERROR, errbuf.getUtf8String(0));
+				throw new PcapException(PcapCode.PCAP_ERROR, errbuf.getString(0, java.nio.charset.StandardCharsets.UTF_8));
 
 			var abi = PcapHeaderABI.selectLiveAbi();
 
@@ -450,13 +450,13 @@ public sealed class Pcap0_4 extends Pcap permits Pcap0_5 {
 		Objects.requireNonNull(fname, "fname"); //$NON-NLS-1$
 
 		try (var arena = newArena()) {
-			MemorySegment c_fname = arena.allocateUtf8String(fname);
+			MemorySegment c_fname = arena.allocateFrom(fname, java.nio.charset.StandardCharsets.UTF_8);
 			MemorySegment errbuf = arena.allocate(PCAP_ERRBUF_SIZE);
 
 			MemorySegment pcapPointer = pcap_open_offline.invokeObj(c_fname, errbuf);
 
 			if (ForeignUtils.isNullAddress(pcapPointer))
-				throw new PcapException(PcapCode.PCAP_ERROR, errbuf.getUtf8String(0));
+				throw new PcapException(PcapCode.PCAP_ERROR, errbuf.getString(0, java.nio.charset.StandardCharsets.UTF_8));
 
 			boolean isSwapped = pcap_is_swapped
 					.invokeInt(pcapPointer) == 1;
@@ -575,7 +575,7 @@ public sealed class Pcap0_4 extends Pcap permits Pcap0_5 {
 		try (var arena = newArena()) {
 			BpFilter bpFilter = new BpFilter(str);
 
-			MemorySegment c_filter = arena.allocateUtf8String(str);
+			MemorySegment c_filter = arena.allocateFrom(str, java.nio.charset.StandardCharsets.UTF_8);
 
 			pcap_compile.invokeInt(this::getErrorString, getPcapHandle(), bpFilter.address(), c_filter, opt, netmask);
 
@@ -734,7 +734,7 @@ public sealed class Pcap0_4 extends Pcap permits Pcap0_5 {
 	@Override
 	public final PcapDumper dumpOpen(String fname) throws PcapException {
 		try (var arena = newArena()) {
-			MemorySegment c_file = arena.allocateUtf8String(fname);
+			MemorySegment c_file = arena.allocateFrom(fname, java.nio.charset.StandardCharsets.UTF_8);
 
 			MemorySegment pcap_dumper_ptr = pcap_dump_open.invokeObj(this::geterr, getPcapHandle(), c_file);
 
@@ -945,7 +945,7 @@ public sealed class Pcap0_4 extends Pcap permits Pcap0_5 {
 	@Override
 	public final Pcap0_4 perror(String prefix) {
 		try (var arena = newArena()) {
-			pcap_perror.invokeVoid(getPcapHandle(), arena.allocateUtf8String(prefix));
+			pcap_perror.invokeVoid(getPcapHandle(), arena.allocateFrom(prefix), java.nio.charset.StandardCharsets.UTF_8);
 
 			return this;
 		}

--- a/src/main/java/org/jnetpcap/Pcap0_5.java
+++ b/src/main/java/org/jnetpcap/Pcap0_5.java
@@ -105,7 +105,7 @@ public sealed class Pcap0_5 extends Pcap0_4 permits Pcap0_6 {
 		try (var arena = newArena()) {
 			BpFilter bpFilter = new BpFilter(str);
 
-			MemorySegment c_filter = arena.allocateUtf8String(str);
+			MemorySegment c_filter = arena.allocateFrom(str, java.nio.charset.StandardCharsets.UTF_8);
 
 			int code = pcap_compile_nopcap.invokeInt(snaplen, pcapDlt.getAsInt(), bpFilter.address(), c_filter, opt,
 					netmask);

--- a/src/main/java/org/jnetpcap/Pcap0_7.java
+++ b/src/main/java/org/jnetpcap/Pcap0_7.java
@@ -197,7 +197,7 @@ public sealed class Pcap0_7 extends Pcap0_6 permits Pcap0_8 {
 
 			/* int pcap_findalldevs(pcap_if_t **alldevsp, char *errbuf) */
 			if (pcap_findalldevs.invokeInt(alldevsp, errbuf) == PcapCode.PCAP_ERROR)
-				throw new PcapException(errbuf.getUtf8String(0));
+				throw new PcapException(errbuf.getString(0, java.nio.charset.StandardCharsets.UTF_8));
 
 			MemorySegment alldev = alldevsp.get(ValueLayout.ADDRESS, 0);
 

--- a/src/main/java/org/jnetpcap/Pcap0_8.java
+++ b/src/main/java/org/jnetpcap/Pcap0_8.java
@@ -215,7 +215,7 @@ public sealed class Pcap0_8 extends Pcap0_7 permits Pcap0_9 {
 	 */
 	public static PcapDlt datalinkNameToVal(String name) {
 		try (var arena = newArena()) {
-			MemorySegment mseg = arena.allocateUtf8String(name);
+			MemorySegment mseg = arena.allocateFrom(name, java.nio.charset.StandardCharsets.UTF_8);
 
 			return PcapDlt.valueOf(pcap_datalink_name_to_val.invokeInt(mseg));
 		}

--- a/src/main/java/org/jnetpcap/Pcap1_0.java
+++ b/src/main/java/org/jnetpcap/Pcap1_0.java
@@ -169,13 +169,13 @@ public sealed class Pcap1_0 extends Pcap0_9 permits Pcap1_2 {
 			MemorySegment c_errbuf = arena.allocate(PcapConstants.PCAP_ERRBUF_SIZE);
 			MemorySegment c_device = arena.allocate(device.length() + 1);
 
-			c_device.setUtf8String(0, device);
+			c_device.setString(0, device, java.nio.charset.StandardCharsets.UTF_8);
 
 			MemorySegment pcapPointer = (MemorySegment) pcap_create.handle().invokeExact(c_device,
 					c_errbuf);
 
 			if (ForeignUtils.isNullAddress(pcapPointer))
-				throw new PcapException(PcapCode.PCAP_ERROR, c_errbuf.getUtf8String(0));
+				throw new PcapException(PcapCode.PCAP_ERROR, c_errbuf.getString(0, java.nio.charset.StandardCharsets.UTF_8));
 
 			var abi = PcapHeaderABI.selectLiveAbi();
 
@@ -258,7 +258,7 @@ public sealed class Pcap1_0 extends Pcap0_9 permits Pcap1_2 {
 
 			int result = pcap_init.invokeInt(opts, errbuf);
 			if (result != PcapCode.PCAP_OK)
-				PcapException.throwIfNotOk(opts, () -> errbuf.getUtf8String(0));
+				PcapException.throwIfNotOk(opts, () -> errbuf.getString(0, java.nio.charset.StandardCharsets.UTF_8));
 		}
 	}
 

--- a/src/main/java/org/jnetpcap/SaLayout.java
+++ b/src/main/java/org/jnetpcap/SaLayout.java
@@ -278,7 +278,7 @@ enum SaLayout {
 		if (varHandle == null)
 			throw new IllegalStateException("Not a value constant");
 
-		return varHandle.get(mseg);
+		return varHandle.get(mseg, 0L);
 	}
 
 	/**

--- a/src/main/java/org/jnetpcap/SockAddr.java
+++ b/src/main/java/org/jnetpcap/SockAddr.java
@@ -591,7 +591,7 @@ public class SockAddr {
 			super(addr.reinterpret(SOCK_ADDR_IRDA_LEN, arena,	EMPTY_CLEANUP), SockAddrFamily.IRDA,	OptionalInt.of(SOCK_ADDR_IRDA_LEN));
 
 			this.irdaDeviceID = saSegment.asSlice(2, 4).toArray(JAVA_BYTE);
-			this.irdaServiceName = saSegment.getUtf8String(6);
+			this.irdaServiceName = saSegment.getString(6, java.nio.charset.StandardCharsets.UTF_8);
 		}
 
 		/**

--- a/src/main/java/org/jnetpcap/internal/ForeignDowncall.java
+++ b/src/main/java/org/jnetpcap/internal/ForeignDowncall.java
@@ -325,7 +325,7 @@ public class ForeignDowncall<E extends Throwable> {
 
 		validateObj(address, messageFactory);
 
-		return address.getUtf8String(0);
+		return address.getString(0, java.nio.charset.StandardCharsets.UTF_8);
 
 	}
 

--- a/src/main/java/org/jnetpcap/internal/ForeignUtils.java
+++ b/src/main/java/org/jnetpcap/internal/ForeignUtils.java
@@ -28,11 +28,11 @@ import java.util.stream.Stream;
  * @author repos@slytechs.com
  */
 public final class ForeignUtils {
-	
+
 	public static final Consumer<MemorySegment> EMPTY_CLEANUP = new Consumer<MemorySegment>() {
 		@Override
 		public void accept(MemorySegment t) {
-			
+
 		}
 	};
 
@@ -72,7 +72,7 @@ public final class ForeignUtils {
 		if (addr.byteSize() == 0)
 			addr = addr.reinterpret(DEFAULT_MAX_STRING_LEN);
 
-		String str = addr.getUtf8String(0);
+		String str = addr.getString(0, java.nio.charset.StandardCharsets.UTF_8);
 		return str;
 	}
 
@@ -84,7 +84,7 @@ public final class ForeignUtils {
 	 * @return the memory segment
 	 */
 	public static MemorySegment readAddress(VarHandle handle, MemorySegment addressAt) {
-		var read = (MemorySegment) handle.get(addressAt);
+		var read = (MemorySegment) handle.get(addressAt, 0L);
 		return read;
 	}
 

--- a/src/main/java/org/jnetpcap/internal/PcapStatExRecord.java
+++ b/src/main/java/org/jnetpcap/internal/PcapStatExRecord.java
@@ -102,88 +102,88 @@ public record PcapStatExRecord(
 			JAVA_LONG.withName("tx_window_errors")
 
 	);
-	
+
 	/** The Constant PCAP_STAT_EX_LENGTH. */
 	public static final int PCAP_STAT_EX_LENGTH = (int) LAYOUT.byteSize();
 
 	/** The Constant ps_recv. */
 	private static final VarHandle ps_recv = LAYOUT.varHandle(groupElement("ps_recv"));
-	
+
 	/** The Constant ps_drop. */
 	private static final VarHandle ps_drop = LAYOUT.varHandle(groupElement("ps_drop"));
-	
+
 	/** The Constant ps_ifdrop. */
 	private static final VarHandle ps_ifdrop = LAYOUT.varHandle(groupElement("ps_ifdrop"));
-	
+
 	/** The Constant ps_capt. */
 	private static final VarHandle ps_capt = LAYOUT.varHandle(groupElement("ps_ifdrop"));
-	
+
 	/** The Constant ps_sent. */
 	private static final VarHandle ps_sent = LAYOUT.varHandle(groupElement("ps_ifdrop"));
-	
+
 	/** The Constant ps_netdrop. */
 	private static final VarHandle ps_netdrop = LAYOUT.varHandle(groupElement("ps_ifdrop"));
 
 	/** The Constant rx_packets. */
 	private static final VarHandle rx_packets = LAYOUT.varHandle(groupElement("rx_packets"));
-	
+
 	/** The Constant tx_packets. */
 	private static final VarHandle tx_packets = LAYOUT.varHandle(groupElement("tx_packets"));
-	
+
 	/** The Constant rx_bytes. */
 	private static final VarHandle rx_bytes = LAYOUT.varHandle(groupElement("rx_bytes"));
-	
+
 	/** The Constant tx_bytes. */
 	private static final VarHandle tx_bytes = LAYOUT.varHandle(groupElement("tx_bytes"));
-	
+
 	/** The Constant rx_errors. */
 	private static final VarHandle rx_errors = LAYOUT.varHandle(groupElement("rx_errors"));
-	
+
 	/** The Constant tx_errors. */
 	private static final VarHandle tx_errors = LAYOUT.varHandle(groupElement("tx_errors"));
-	
+
 	/** The Constant rx_dropped. */
 	private static final VarHandle rx_dropped = LAYOUT.varHandle(groupElement("rx_dropped"));
-	
+
 	/** The Constant tx_dropped. */
 	private static final VarHandle tx_dropped = LAYOUT.varHandle(groupElement("tx_dropped"));
-	
+
 	/** The Constant multicast_cnt. */
 	private static final VarHandle multicast_cnt = LAYOUT.varHandle(groupElement("multicast_cnt"));
-	
+
 	/** The Constant collisions_cnt. */
 	private static final VarHandle collisions_cnt = LAYOUT.varHandle(groupElement("collisions_cnt"));
 
 	/** The Constant rx_length_errors. */
 	private static final VarHandle rx_length_errors = LAYOUT.varHandle(groupElement("rx_length_errors"));
-	
+
 	/** The Constant rx_over_errors. */
 	private static final VarHandle rx_over_errors = LAYOUT.varHandle(groupElement("rx_over_errors"));
-	
+
 	/** The Constant rx_crc_errors. */
 	private static final VarHandle rx_crc_errors = LAYOUT.varHandle(groupElement("rx_crc_errors"));
-	
+
 	/** The Constant rx_frame_errors. */
 	private static final VarHandle rx_frame_errors = LAYOUT.varHandle(groupElement("rx_frame_errors"));
-	
+
 	/** The Constant rx_fifo_errors. */
 	private static final VarHandle rx_fifo_errors = LAYOUT.varHandle(groupElement("rx_fifo_errors"));
-	
+
 	/** The Constant rx_missed_errors. */
 	private static final VarHandle rx_missed_errors = LAYOUT.varHandle(groupElement("rx_missed_errors"));
 
 	/** The Constant tx_aborted_errors. */
 	private static final VarHandle tx_aborted_errors = LAYOUT.varHandle(groupElement("tx_aborted_errors"));
-	
+
 	/** The Constant tx_carrier_errors. */
 	private static final VarHandle tx_carrier_errors = LAYOUT.varHandle(groupElement("tx_carrier_errors"));
-	
+
 	/** The Constant tx_fifo_errors. */
 	private static final VarHandle tx_fifo_errors = LAYOUT.varHandle(groupElement("tx_fifo_errors"));
-	
+
 	/** The Constant tx_heartbeat_errors. */
 	private static final VarHandle tx_heartbeat_errors = LAYOUT.varHandle(groupElement("tx_heartbeat_errors"));
-	
+
 	/** The Constant tx_window_errors. */
 	private static final VarHandle tx_window_errors = LAYOUT.varHandle(groupElement("tx_window_errors"));
 
@@ -197,36 +197,36 @@ public record PcapStatExRecord(
 		this(
 				size,
 
-				toUnsignedLong((int) ps_recv.get(mseg)),
-				toUnsignedLong((int) ps_drop.get(mseg)),
-				toUnsignedLong((int) ps_ifdrop.get(mseg)),
-				toUnsignedLong((int) ps_capt.get(mseg)),
-				toUnsignedLong((int) ps_sent.get(mseg)),
-				toUnsignedLong((int) ps_netdrop.get(mseg)),
+				toUnsignedLong((int) ps_recv.get(mseg, 0L)),
+				toUnsignedLong((int) ps_drop.get(mseg, 0L)),
+				toUnsignedLong((int) ps_ifdrop.get(mseg, 0L)),
+				toUnsignedLong((int) ps_capt.get(mseg, 0L)),
+				toUnsignedLong((int) ps_sent.get(mseg, 0L)),
+				toUnsignedLong((int) ps_netdrop.get(mseg, 0L)),
 
-				(long) rx_packets.get(mseg),
-				(long) tx_packets.get(mseg),
-				(long) rx_bytes.get(mseg),
-				(long) tx_bytes.get(mseg),
-				(long) rx_errors.get(mseg),
-				(long) tx_errors.get(mseg),
-				(long) rx_dropped.get(mseg),
-				(long) tx_dropped.get(mseg),
-				(long) multicast_cnt.get(mseg),
-				(long) collisions_cnt.get(mseg),
+				(long) rx_packets.get(mseg, 0L),
+				(long) tx_packets.get(mseg, 0L),
+				(long) rx_bytes.get(mseg, 0L),
+				(long) tx_bytes.get(mseg, 0L),
+				(long) rx_errors.get(mseg, 0L),
+				(long) tx_errors.get(mseg, 0L),
+				(long) rx_dropped.get(mseg, 0L),
+				(long) tx_dropped.get(mseg, 0L),
+				(long) multicast_cnt.get(mseg, 0L),
+				(long) collisions_cnt.get(mseg, 0L),
 
-				(long) rx_length_errors.get(mseg),
-				(long) rx_over_errors.get(mseg),
-				(long) rx_crc_errors.get(mseg),
-				(long) rx_frame_errors.get(mseg),
-				(long) rx_fifo_errors.get(mseg),
-				(long) rx_missed_errors.get(mseg),
+				(long) rx_length_errors.get(mseg, 0L),
+				(long) rx_over_errors.get(mseg, 0L),
+				(long) rx_crc_errors.get(mseg, 0L),
+				(long) rx_frame_errors.get(mseg, 0L),
+				(long) rx_fifo_errors.get(mseg, 0L),
+				(long) rx_missed_errors.get(mseg, 0L),
 
-				(long) tx_aborted_errors.get(mseg),
-				(long) tx_carrier_errors.get(mseg),
-				(long) tx_fifo_errors.get(mseg),
-				(long) tx_heartbeat_errors.get(mseg),
-				(long) tx_window_errors.get(mseg)
+				(long) tx_aborted_errors.get(mseg, 0L),
+				(long) tx_carrier_errors.get(mseg, 0L),
+				(long) tx_fifo_errors.get(mseg, 0L),
+				(long) tx_heartbeat_errors.get(mseg, 0L),
+				(long) tx_window_errors.get(mseg, 0L)
 
 		);
 	}

--- a/src/main/java/org/jnetpcap/internal/PcapStatRecord.java
+++ b/src/main/java/org/jnetpcap/internal/PcapStatRecord.java
@@ -29,7 +29,7 @@ import org.jnetpcap.windows.WinPcap;
 
 /**
  * Packet statistics from the start of the pcap run to the time of the call.
- * 
+ *
  * <p>
  * A struct pcap_stat has the following members:
  * <dl>
@@ -58,7 +58,7 @@ import org.jnetpcap.windows.WinPcap;
  * or it might mean that the statistic is unavailable, so it should not be
  * treated as an indication that the interface did not drop any packets.
  * </p>
- * 
+ *
  * @author Sly Technologies Inc
  * @author repos@slytechs.com
  * @author mark
@@ -79,19 +79,19 @@ public record PcapStatRecord(long recv, long drop, long ifdrop, long capt, long 
 
 	/** The Constant ps_recv. */
 	private static final VarHandle ps_recv = LAYOUT.varHandle(groupElement("ps_recv"));
-	
+
 	/** The Constant ps_drop. */
 	private static final VarHandle ps_drop = LAYOUT.varHandle(groupElement("ps_drop"));
-	
+
 	/** The Constant ps_ifdrop. */
 	private static final VarHandle ps_ifdrop = LAYOUT.varHandle(groupElement("ps_ifdrop"));
-	
+
 	/** The Constant ps_capt. */
 	private static final VarHandle ps_capt = LAYOUT.varHandle(groupElement("ps_ifdrop"));
-	
+
 	/** The Constant ps_sent. */
 	private static final VarHandle ps_sent = LAYOUT.varHandle(groupElement("ps_ifdrop"));
-	
+
 	/** The Constant ps_netdrop. */
 	private static final VarHandle ps_netdrop = LAYOUT.varHandle(groupElement("ps_ifdrop"));
 
@@ -106,9 +106,9 @@ public record PcapStatRecord(long recv, long drop, long ifdrop, long capt, long 
 			return ofMemoryOnWin32(mseg);
 
 		return new PcapStatRecord(
-				toUnsignedLong((int) ps_recv.get(mseg)),
-				toUnsignedLong((int) ps_drop.get(mseg)),
-				toUnsignedLong((int) ps_ifdrop.get(mseg)),
+				toUnsignedLong((int) ps_recv.get(mseg, 0L)),
+				toUnsignedLong((int) ps_drop.get(mseg, 0L)),
+				toUnsignedLong((int) ps_ifdrop.get(mseg, 0L)),
 				0, 0, 0);
 	}
 
@@ -120,12 +120,12 @@ public record PcapStatRecord(long recv, long drop, long ifdrop, long capt, long 
 	 */
 	private static PcapStat ofMemoryOnWin32(MemorySegment mseg) {
 		return new PcapStatRecord(
-				toUnsignedLong((int) ps_recv.get(mseg)),
-				toUnsignedLong((int) ps_drop.get(mseg)),
-				toUnsignedLong((int) ps_ifdrop.get(mseg)),
-				toUnsignedLong((int) ps_capt.get(mseg)),
-				toUnsignedLong((int) ps_sent.get(mseg)),
-				toUnsignedLong((int) ps_netdrop.get(mseg)));
+				toUnsignedLong((int) ps_recv.get(mseg, 0L)),
+				toUnsignedLong((int) ps_drop.get(mseg, 0L)),
+				toUnsignedLong((int) ps_ifdrop.get(mseg, 0L)),
+				toUnsignedLong((int) ps_capt.get(mseg, 0L)),
+				toUnsignedLong((int) ps_sent.get(mseg, 0L)),
+				toUnsignedLong((int) ps_netdrop.get(mseg, 0L)));
 	}
 
 }

--- a/src/main/java/org/jnetpcap/windows/PcapRmt.java
+++ b/src/main/java/org/jnetpcap/windows/PcapRmt.java
@@ -27,7 +27,7 @@ import static java.lang.foreign.ValueLayout.*;
 
 /**
  * Remote RPCAP authentication and source string marker interface.
- * 
+ *
  * @author Sly Technologies Inc
  * @author repos@slytechs.com
  * @author mark
@@ -72,10 +72,10 @@ public sealed interface PcapRmt permits PcapRmt.Source, PcapRmt.Auth {
 
 		/** The Constant rmtauth_type. */
 		private static final VarHandle rmtauth_type = LAYOUT.varHandle(PathElement.groupElement("type"));
-		
+
 		/** The Constant rmtauth_username. */
 		private static final VarHandle rmtauth_username = LAYOUT.varHandle(PathElement.groupElement("username"));
-		
+
 		/** The Constant rmtauth_password. */
 		private static final VarHandle rmtauth_password = LAYOUT.varHandle(PathElement.groupElement("password"));
 
@@ -99,12 +99,12 @@ public sealed interface PcapRmt permits PcapRmt.Source, PcapRmt.Auth {
 		MemorySegment allocateNative(Arena arena) {
 			MemorySegment mseg = arena.allocate(LAYOUT.byteSize());
 
-			MemorySegment c_username = arena.allocateUtf8String(username);
-			MemorySegment c_password = arena.allocateUtf8String(password);
+			MemorySegment c_username = arena.allocateFrom(username, java.nio.charset.StandardCharsets.UTF_8);
+			MemorySegment c_password = arena.allocateFrom(password, java.nio.charset.StandardCharsets.UTF_8);
 
-			rmtauth_type.set(mseg, type);
-			rmtauth_username.set(mseg, c_username);
-			rmtauth_password.set(mseg, c_password);
+			rmtauth_type.set(mseg, 0L, type);
+			rmtauth_username.set(mseg, 0L, c_username);
+			rmtauth_password.set(mseg, 0L, c_password);
 
 			return mseg;
 		}

--- a/src/main/java/org/jnetpcap/windows/PcapSendQueue.java
+++ b/src/main/java/org/jnetpcap/windows/PcapSendQueue.java
@@ -30,7 +30,7 @@ import org.jnetpcap.internal.PcapForeignInitializer;
 /**
  * A queue of raw packets that will be sent to the network with {@code transmit}
  * on Microsoft Windows platforms.
- * 
+ *
  * @author Sly Technologies Inc
  * @author repos@slytechs.com
  * @author mark
@@ -39,12 +39,12 @@ public class PcapSendQueue implements AutoCloseable {
 
 	/**
 	 * The Class Struct.
-	 * 
+	 *
 	 * <pre>
 	struct pcap_send_queue {
 		u_int maxlen;	// Maximum size of the queue, in bytes. This variable contains the size of the buffer field.
 		u_int len;	// Current size of the queue, in bytes.
-		char *buffer;	// Buffer containing the packets to be sent. 
+		char *buffer;	// Buffer containing the packets to be sent.
 	};
 	 * </pre>
 	 */
@@ -127,7 +127,7 @@ public class PcapSendQueue implements AutoCloseable {
 	 * </p>
 	 * Use pcap_sendqueue_queue() to insert packets in the queue.
 	 * </p>
-	 * 
+	 *
 	 * @param capacity maximum size of the send queue in bytes
 	 * @return address of the allocated sendqueue
 	 */
@@ -181,7 +181,7 @@ public class PcapSendQueue implements AutoCloseable {
 
 	/**
 	 * Add a packet to a send queue.
-	 * 
+	 *
 	 * <p>
 	 * pcap_sendqueue_queue() adds a packet at the end of the send queue pointed by
 	 * the queue parameter. pkt_header points to a pcap_pkthdr structure with the
@@ -207,7 +207,7 @@ public class PcapSendQueue implements AutoCloseable {
 
 	/**
 	 * Add a packet to a send queue.
-	 * 
+	 *
 	 * <p>
 	 * pcap_sendqueue_queue() adds a packet at the end of the send queue pointed by
 	 * the queue parameter. pkt_header points to a pcap_pkthdr structure with the
@@ -287,7 +287,7 @@ public class PcapSendQueue implements AutoCloseable {
 	 * @return the maxlen or capacity, in bytes, of this send queue
 	 */
 	public int maxlen() {
-		return (int) Struct.MAXLEN.get(queue_ptr);
+		return (int) Struct.MAXLEN.get(queue_ptr, 0L);
 	}
 
 	/**
@@ -296,6 +296,6 @@ public class PcapSendQueue implements AutoCloseable {
 	 * @return the length or current size, in bytes, of this send queue
 	 */
 	public int len() {
-		return (int) Struct.LEN.get(queue_ptr);
+		return (int) Struct.LEN.get(queue_ptr, 0L);
 	}
 }

--- a/src/main/java/org/jnetpcap/windows/WinPcap.java
+++ b/src/main/java/org/jnetpcap/windows/WinPcap.java
@@ -249,14 +249,14 @@ public sealed class WinPcap extends Pcap1_10 permits Npcap {
 			MemorySegment c_source = arena.allocate(PCAP_BUF_SIZE);
 			MemorySegment errbuf = arena.allocate(PCAP_ERRBUF_SIZE);
 
-			MemorySegment c_host = (host != null) ? arena.allocateUtf8String(host) : NULL;
-			MemorySegment c_port = (port != null) ? arena.allocateUtf8String(port) : NULL;
-			MemorySegment c_name = (name != null) ? arena.allocateUtf8String(name) : NULL;
+			MemorySegment c_host = (host != null) ? arena.allocateFrom(host, java.nio.charset.StandardCharsets.UTF_8) : NULL;
+			MemorySegment c_port = (port != null) ? arena.allocateFrom(port, java.nio.charset.StandardCharsets.UTF_8) : NULL;
+			MemorySegment c_name = (name != null) ? arena.allocateFrom(name, java.nio.charset.StandardCharsets.UTF_8) : NULL;
 
 			int result = pcap_createsrcstr.invokeInt(c_source, type.getAsInt(), c_host, c_port, c_name, errbuf);
-			PcapException.throwIfNotOk(result, () -> errbuf.getUtf8String(0));
+			PcapException.throwIfNotOk(result, () -> errbuf.getString(0, java.nio.charset.StandardCharsets.UTF_8));
 
-			return c_source.getUtf8String(0);
+			return c_source.getString(0, java.nio.charset.StandardCharsets.UTF_8);
 		}
 	}
 
@@ -314,13 +314,13 @@ public sealed class WinPcap extends Pcap1_10 permits Npcap {
 		password = password == null ? "" : password;
 
 		try (var arena = newArena()) {
-			MemorySegment c_source = arena.allocateUtf8String(source);
+			MemorySegment c_source = arena.allocateFrom(source, java.nio.charset.StandardCharsets.UTF_8);
 			MemorySegment c_alldevsp = arena.allocate(ADDRESS);
 			MemorySegment c_rmtauth = new PcapRmt.Auth(type, username, password).allocateNative(arena);
 			MemorySegment errbuf = arena.allocate(PCAP_ERRBUF_SIZE);
 
 			int result = pcap_findalldevs_ex.invokeInt(c_source, c_rmtauth, c_alldevsp, errbuf);
-			PcapException.throwIfNotOk(result, () -> errbuf.getUtf8String(0));
+			PcapException.throwIfNotOk(result, () -> errbuf.getString(0, java.nio.charset.StandardCharsets.UTF_8));
 
 			return listAllPcapIf(c_alldevsp.get(ADDRESS, 0), arena);
 		}
@@ -487,19 +487,19 @@ public sealed class WinPcap extends Pcap1_10 permits Npcap {
 		try (var arena = newArena()) {
 			MemorySegment errbuf = arena.allocate(PCAP_ERRBUF_SIZE);
 
-			MemorySegment c_source = arena.allocateUtf8String(source);
+			MemorySegment c_source = arena.allocateFrom(source, java.nio.charset.StandardCharsets.UTF_8);
 			MemorySegment c_type = arena.allocate(JAVA_INT);
 			MemorySegment c_host = arena.allocate( PCAP_BUF_SIZE);
 			MemorySegment c_port = arena.allocate(PCAP_BUF_SIZE);
 			MemorySegment c_name = arena.allocate(PCAP_BUF_SIZE);
 
 			int result = pcap_parsesrcstr.invokeInt(c_source, c_type, c_host, c_port, c_name, errbuf);
-			PcapException.throwIfNotOk(result, () -> errbuf.getUtf8String(0));
+			PcapException.throwIfNotOk(result, () -> errbuf.getString(0, java.nio.charset.StandardCharsets.UTF_8));
 
 			int type = c_type.get(JAVA_INT, 0);
-			String host = c_host.getUtf8String(0);
-			String port = c_port.getUtf8String(0);
-			String name = c_name.getUtf8String(0);
+			String host = c_host.getString(0, java.nio.charset.StandardCharsets.UTF_8);
+			String port = c_port.getString(0, java.nio.charset.StandardCharsets.UTF_8);
+			String name = c_name.getString(0, java.nio.charset.StandardCharsets.UTF_8);
 
 			PcapRmt.Source srcString = new PcapRmt.Source(type, host, port, name);
 
@@ -586,7 +586,7 @@ public sealed class WinPcap extends Pcap1_10 permits Npcap {
 	 */
 	public void liveDump(String filename, int maxsize, int maxpacks) throws PcapException {
 		try (var arena = newArena()) {
-			MemorySegment c_filename = arena.allocateUtf8String(filename);
+			MemorySegment c_filename = arena.allocateFrom(filename, java.nio.charset.StandardCharsets.UTF_8);
 			pcap_live_dump.invokeInt(this::geterr,  getPcapHandle(), c_filename, maxsize, maxpacks);
 		}
 	}


### PR DESCRIPTION
The title is self descriptive.
The latest release binaries fail to link against the final FF API in JDK22.
I've made little changes here and there to ensure compatibility and tested it on my own product which used old JNetPcap 1.4.