### PR TITLE
Fixed the issue with IndexOutOfBound in Java 23

### DIFF
--- a/src/main/java/org/jnetpcap/SaLayout.java
+++ b/src/main/java/org/jnetpcap/SaLayout.java
@@ -248,15 +248,13 @@ enum SaLayout {
 	 * @param elements the elements
 	 */
 	SaLayout(String path, PathElement... elements) {
-		PathElement[] parsed = path(path);
 		fullPaths = Stream.concat(Stream.of(path(path)), Stream.of(elements))
 				.toArray(PathElement[]::new);
 
 		if (path.endsWith(".last"))
 			this.varHandle = null;
 		else
-			this.varHandle = Initializer.SOCK_ADDR_LAYOUT.varHandle(fullPaths);
-
+			this.varHandle = Initializer.SOCK_ADDR_LAYOUT.select(fullPaths).varHandle();
 	}
 
 	/**


### PR DESCRIPTION
After installing _Java 23_, I saw an `IndexOutOfBound` exception when calling `org.jnetpcap.Pcap.findAllDevs()`. Tracing it, the issue was attributed to how the `varHandle` in `org.jnetpcap.SaLayout.get(MemorySegment)` was being used to fetch data from a reinterpreted union memory segment.

Comparing `MemorySegment` and related classes of Java foreign memory access between _Java 22 and 23_, I found out this is an extra check put in place in _Java 23_ which enforces proper memory mapping for unions from Java side.

This fix is tested on many usecases and passes them all and allows me using the library with **Java 23**.
